### PR TITLE
Also identify (doc)Strings for the pep8_comment_text_width limit

### DIFF
--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -24,7 +24,7 @@ augroup END
 function! s:GetCurrentTextWidth()
     let curr_syntax = synIDattr(synIDtrans(synID(line("."), col("."), 0)), "name")
     let prev_syntax = synIDattr(synIDtrans(synID(line("."), col(".")-1, 0)), "name")
-    if curr_syntax =~ 'Comment\|Constant' || prev_syntax =~ 'Comment\|Constant'
+    if curr_syntax =~ 'Comment\|Constant\|String' || prev_syntax =~ 'Comment\|Constant\|String'
         return g:pep8_comment_text_width
     endif
 


### PR DESCRIPTION
Thanks for creating this plugin. I reached here from the SO comment that led to this. Just wanted to update this plugin to also apply the `pep8_comment_text_width` limit to doc strings, as pep8 recommends.
